### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -17,7 +17,7 @@ class EventTest extends TestCase
     /** @var array */
     protected $log = [];
 
-    public function setUp()
+    protected function setUp()
     {
         $states = StateCollection::withStateNames([
             'pending',

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -16,7 +16,7 @@ class StateMachineTest extends TestCase
     /** @var StateMachine */
     protected $machine;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->machine = StateMachine::withStates(State::withName('pending'), StateCollection::withStates([
             State::withName('pending'),


### PR DESCRIPTION
This PR
- [x] reduces the visibility of `setUp()` from `public` to `protected`
